### PR TITLE
Force int() for comparison.

### DIFF
--- a/bin/swift-bench
+++ b/bin/swift-bench
@@ -132,7 +132,7 @@ if __name__ == '__main__':
     if options.saio:
         CONF_DEFAULTS.update(SAIO_DEFAULTS)
     if getattr(options, 'lower_object_size', None):
-        if options.object_size <= options.lower_object_size:
+        if int(options.object_size) <= int(options.lower_object_size):
             raise ValueError('--lower-object-size (%s) must be '
                              '< --object-size (%s)' %
                              (options.lower_object_size, options.object_size))


### PR DESCRIPTION
In it point the python compare two strings. For example,If the first byte --lower-object-size greater than the first byte of the --object-size - we get error:
#swift-bench -U user:admin -K pass -A http://localhost:60000/auth/v1.0 --concurrency=200 --num-containers=200 --num-objects=10000 --lower-object-size=2048 --object-size=128000
False
Traceback (most recent call last):
  File "/usr/bin/swift-bench", line 140, in <module>
    (options.lower_object_size, options.object_size))
ValueError: --lower-object-size (2048) must be < --object-size (128000)
